### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that wraps the [People Data Labs API](https://docs.peopledatalabs.com/). It provides comprehensive access to People Data Labs' various data models and search capabilities.
 
+<a href="https://glama.ai/mcp/servers/@phxdev1/peopledatalabs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@phxdev1/peopledatalabs-mcp/badge" alt="People Data Labs Server MCP server" />
+</a>
+
 ## Features
 
 ### Person API


### PR DESCRIPTION
This PR adds a badge for the [People Data Labs MCP Server](https://glama.ai/mcp/servers/@phxdev1/peopledatalabs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@phxdev1/peopledatalabs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@phxdev1/peopledatalabs-mcp/badge" alt="People Data Labs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.